### PR TITLE
feat: generate JSON schemas from Go protocol types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: generate test vet
+
+generate: ## Regenerate JSON schemas from Go protocol types
+	go run ./cmd/generate-schemas/
+
+test: ## Run all tests
+	go test -v ./...
+
+vet: ## Run go vet
+	go vet ./...

--- a/cmd/generate-schemas/main.go
+++ b/cmd/generate-schemas/main.go
@@ -1,0 +1,126 @@
+// Command generate-schemas reflects on the protocol package types and writes
+// JSON Schema files to the schemas/ directory.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/kova-land/extension-sdk-go/protocol"
+)
+
+func main() {
+	types := []any{
+		protocol.Request{},
+		protocol.Response{},
+		protocol.Notification{},
+		protocol.RPCError{},
+		protocol.InitializeParams{},
+		protocol.InitializeResult{},
+		protocol.Registrations{},
+		protocol.ToolDef{},
+		protocol.HTTPRouteDef{},
+		protocol.HookDef{},
+		protocol.ServiceDef{},
+		protocol.ProviderDef{},
+		protocol.TTSProviderDef{},
+		protocol.CLIDef{},
+		protocol.CallContext{},
+		protocol.ToolCallParams{},
+		protocol.ToolCallResult{},
+		protocol.ChannelMessageParams{},
+		protocol.ChannelMessageImage{},
+		protocol.ChannelSendParams{},
+		protocol.ChannelSendAttachment{},
+		protocol.ChannelSendComponent{},
+		protocol.ChannelTypingParams{},
+		protocol.ChannelReactionAddParams{},
+		protocol.ChannelReactionRemoveParams{},
+		protocol.PromptOption{},
+		protocol.PromptUserParams{},
+		protocol.PromptUserResult{},
+		protocol.ChannelCapabilities{},
+		protocol.ChannelCapabilitiesParams{},
+		protocol.ChannelCapabilitiesResult{},
+		protocol.HookEventParams{},
+		protocol.HookEventResult{},
+		protocol.HTTPRequestParams{},
+		protocol.HTTPResponseResult{},
+		protocol.ServiceStartParams{},
+		protocol.ServiceStartResult{},
+		protocol.ServiceHealthParams{},
+		protocol.ServiceHealthResult{},
+		protocol.ServiceStopParams{},
+		protocol.ServiceStopResult{},
+		protocol.ProviderContentBlock{},
+		protocol.ProviderMessage{},
+		protocol.ProviderToolDef{},
+		protocol.ProviderCreateMessageParams{},
+		protocol.ProviderCreateMessageResult{},
+		protocol.StreamChunkParams{},
+		protocol.StreamEndParams{},
+		protocol.StreamErrorParams{},
+		protocol.ProviderCapabilitiesParams{},
+		protocol.ProviderCapabilitiesResult{},
+		protocol.TTSSynthesizeParams{},
+		protocol.TTSSynthesizeResult{},
+		protocol.TTSVoicesResult{},
+		protocol.TTSVoice{},
+		protocol.LogParams{},
+	}
+
+	outDir := "schemas"
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		log.Fatalf("create schemas dir: %v", err)
+	}
+
+	opts := &jsonschema.ForOptions{
+		IgnoreInvalidTypes: true,
+	}
+
+	var errors []string
+
+	for _, instance := range types {
+		t := reflect.TypeOf(instance)
+		name := t.Name()
+		filename := name + ".json"
+
+		schema, err := jsonschema.ForType(t, opts)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", filename, err))
+			continue
+		}
+
+		schema.Title = name
+
+		data, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: marshal: %v", filename, err))
+			continue
+		}
+
+		data = append(data, '\n')
+
+		outPath := filepath.Join(outDir, filename)
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: write: %v", filename, err))
+			continue
+		}
+		fmt.Printf("wrote %s\n", outPath)
+	}
+
+	if len(errors) > 0 {
+		for _, e := range errors {
+			log.Printf("ERROR: %s", e)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nGenerated %d schemas in %s/\n", len(types), outDir)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kova-land/extension-sdk-go
 
 go 1.24
+
+require github.com/google/jsonschema-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=

--- a/protocol/doc.go
+++ b/protocol/doc.go
@@ -18,4 +18,6 @@
 //   - http.go: HTTP route param/result types
 //   - tts.go: TTS provider param/result types
 //   - log.go: Log notification param types
+//
+//go:generate go run ../cmd/generate-schemas/
 package protocol

--- a/schemas/CLIDef.json
+++ b/schemas/CLIDef.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "command": {
+      "type": "string"
+    },
+    "args": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "title": "CLIDef",
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/CallContext.json
+++ b/schemas/CallContext.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "agent_id": {
+      "type": "string"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "platform": {
+      "type": "string"
+    },
+    "channel_id": {
+      "type": "string"
+    }
+  },
+  "title": "CallContext",
+  "additionalProperties": false
+}

--- a/schemas/ChannelCapabilities.json
+++ b/schemas/ChannelCapabilities.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "properties": {
+    "supports_text": {
+      "type": "boolean"
+    },
+    "supports_images": {
+      "type": "boolean"
+    },
+    "supports_audio": {
+      "type": "boolean"
+    },
+    "supports_files": {
+      "type": "boolean"
+    },
+    "supports_voice": {
+      "type": "boolean"
+    },
+    "supports_reactions": {
+      "type": "boolean"
+    },
+    "supports_buttons": {
+      "type": "boolean"
+    },
+    "supports_modals": {
+      "type": "boolean"
+    },
+    "supports_typing": {
+      "type": "boolean"
+    },
+    "max_message_len": {
+      "type": "integer"
+    }
+  },
+  "title": "ChannelCapabilities",
+  "required": [
+    "supports_text"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelCapabilitiesParams.json
+++ b/schemas/ChannelCapabilitiesParams.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelCapabilitiesParams",
+  "additionalProperties": false
+}

--- a/schemas/ChannelCapabilitiesResult.json
+++ b/schemas/ChannelCapabilitiesResult.json
@@ -1,0 +1,49 @@
+{
+  "type": "object",
+  "properties": {
+    "capabilities": {
+      "type": "object",
+      "properties": {
+        "supports_text": {
+          "type": "boolean"
+        },
+        "supports_images": {
+          "type": "boolean"
+        },
+        "supports_audio": {
+          "type": "boolean"
+        },
+        "supports_files": {
+          "type": "boolean"
+        },
+        "supports_voice": {
+          "type": "boolean"
+        },
+        "supports_reactions": {
+          "type": "boolean"
+        },
+        "supports_buttons": {
+          "type": "boolean"
+        },
+        "supports_modals": {
+          "type": "boolean"
+        },
+        "supports_typing": {
+          "type": "boolean"
+        },
+        "max_message_len": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "supports_text"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "title": "ChannelCapabilitiesResult",
+  "required": [
+    "capabilities"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelMessageImage.json
+++ b/schemas/ChannelMessageImage.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    },
+    "mime_type": {
+      "type": "string"
+    },
+    "filename": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelMessageImage",
+  "required": [
+    "data",
+    "mime_type"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelMessageParams.json
+++ b/schemas/ChannelMessageParams.json
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    },
+    "message_id": {
+      "type": "string"
+    },
+    "user_id": {
+      "type": "string"
+    },
+    "username": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "platform": {
+      "type": "string"
+    },
+    "images": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "mime_type"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "ChannelMessageParams",
+  "required": [
+    "channel_id",
+    "text",
+    "platform"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelReactionAddParams.json
+++ b/schemas/ChannelReactionAddParams.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    },
+    "message_id": {
+      "type": "string"
+    },
+    "emoji": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelReactionAddParams",
+  "required": [
+    "channel_id",
+    "message_id",
+    "emoji"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelReactionRemoveParams.json
+++ b/schemas/ChannelReactionRemoveParams.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    },
+    "message_id": {
+      "type": "string"
+    },
+    "emoji": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelReactionRemoveParams",
+  "required": [
+    "channel_id",
+    "message_id",
+    "emoji"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelSendAttachment.json
+++ b/schemas/ChannelSendAttachment.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    },
+    "mime_type": {
+      "type": "string"
+    },
+    "filename": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelSendAttachment",
+  "required": [
+    "data",
+    "mime_type",
+    "filename"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelSendComponent.json
+++ b/schemas/ChannelSendComponent.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "label": {
+      "type": "string"
+    },
+    "custom_id": {
+      "type": "string"
+    },
+    "style": {
+      "type": "integer"
+    }
+  },
+  "title": "ChannelSendComponent",
+  "required": [
+    "label",
+    "custom_id",
+    "style"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelSendParams.json
+++ b/schemas/ChannelSendParams.json
@@ -1,0 +1,151 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "images": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "mime_type",
+          "filename"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "audio": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "mime_type",
+          "filename"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "files": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "mime_type",
+          "filename"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "components": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "custom_id": {
+              "type": "string"
+            },
+            "style": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "label",
+            "custom_id",
+            "style"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "title": "ChannelSendParams",
+  "required": [
+    "channel_id",
+    "text"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ChannelTypingParams.json
+++ b/schemas/ChannelTypingParams.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    }
+  },
+  "title": "ChannelTypingParams",
+  "required": [
+    "channel_id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HTTPRequestParams.json
+++ b/schemas/HTTPRequestParams.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "method": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "body": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "title": "HTTPRequestParams",
+  "required": [
+    "method",
+    "path",
+    "headers"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HTTPResponseResult.json
+++ b/schemas/HTTPResponseResult.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "status_code": {
+      "type": "integer"
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "body": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "title": "HTTPResponseResult",
+  "required": [
+    "status_code"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HTTPRouteDef.json
+++ b/schemas/HTTPRouteDef.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "methods": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "title": "HTTPRouteDef",
+  "required": [
+    "path",
+    "methods"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HookDef.json
+++ b/schemas/HookDef.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "events": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "matcher": {
+      "type": "string"
+    }
+  },
+  "title": "HookDef",
+  "required": [
+    "events"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HookEventParams.json
+++ b/schemas/HookEventParams.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "event": {
+      "type": "string"
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "title": "HookEventParams",
+  "required": [
+    "event",
+    "data"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/HookEventResult.json
+++ b/schemas/HookEventResult.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "title": "HookEventResult",
+  "additionalProperties": false
+}

--- a/schemas/InitializeParams.json
+++ b/schemas/InitializeParams.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "config": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "extension_root": {
+      "type": "string"
+    },
+    "agent_name": {
+      "type": "string"
+    },
+    "agent_version": {
+      "type": "string"
+    }
+  },
+  "title": "InitializeParams",
+  "required": [
+    "config",
+    "extension_root"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/InitializeResult.json
+++ b/schemas/InitializeResult.json
@@ -1,0 +1,194 @@
+{
+  "type": "object",
+  "properties": {
+    "registrations": {
+      "type": "object",
+      "properties": {
+        "tools": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "input_schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "description",
+              "input_schema"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "http_routes": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "methods": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "path",
+              "methods"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "hooks": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "events": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "matcher": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "events"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "services": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "providers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "tts_providers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "cli_commands": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "args": {
+                "type": [
+                  "null",
+                  "array"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "title": "InitializeResult",
+  "required": [
+    "registrations"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/LogParams.json
+++ b/schemas/LogParams.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "level": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "title": "LogParams",
+  "required": [
+    "level",
+    "message"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/Notification.json
+++ b/schemas/Notification.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "jsonrpc": {
+      "type": "string"
+    },
+    "method": {
+      "type": "string"
+    },
+    "params": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "title": "Notification",
+  "required": [
+    "jsonrpc",
+    "method"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/PromptOption.json
+++ b/schemas/PromptOption.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "label": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    },
+    "style": {
+      "type": "string"
+    }
+  },
+  "title": "PromptOption",
+  "required": [
+    "label",
+    "value"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/PromptUserParams.json
+++ b/schemas/PromptUserParams.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+  "properties": {
+    "channel_id": {
+      "type": "string"
+    },
+    "user_id": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "options": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "style": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "value"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "allow_text": {
+      "type": "boolean"
+    },
+    "text_placeholder": {
+      "type": "string"
+    },
+    "timeout_seconds": {
+      "type": "integer"
+    }
+  },
+  "title": "PromptUserParams",
+  "required": [
+    "channel_id",
+    "message"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/PromptUserResult.json
+++ b/schemas/PromptUserResult.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "selected_option": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "timed_out": {
+      "type": "boolean"
+    },
+    "dismissed": {
+      "type": "boolean"
+    }
+  },
+  "title": "PromptUserResult",
+  "additionalProperties": false
+}

--- a/schemas/ProviderCapabilitiesParams.json
+++ b/schemas/ProviderCapabilitiesParams.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string"
+    }
+  },
+  "title": "ProviderCapabilitiesParams",
+  "additionalProperties": false
+}

--- a/schemas/ProviderCapabilitiesResult.json
+++ b/schemas/ProviderCapabilitiesResult.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "models": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "supports_streaming": {
+      "type": "boolean"
+    },
+    "supports_vision": {
+      "type": "boolean"
+    },
+    "supports_audio_output": {
+      "type": "boolean"
+    },
+    "max_images": {
+      "type": "integer"
+    },
+    "max_tokens": {
+      "type": "integer"
+    },
+    "context_window": {
+      "type": "integer"
+    }
+  },
+  "title": "ProviderCapabilitiesResult",
+  "required": [
+    "supports_streaming"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderContentBlock.json
+++ b/schemas/ProviderContentBlock.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "input": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    },
+    "output": {
+      "type": "string"
+    },
+    "is_error": {
+      "type": "boolean"
+    }
+  },
+  "title": "ProviderContentBlock",
+  "required": [
+    "type"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderCreateMessageParams.json
+++ b/schemas/ProviderCreateMessageParams.json
@@ -1,0 +1,141 @@
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string"
+    },
+    "max_tokens": {
+      "type": "integer"
+    },
+    "system_prompt": {
+      "type": "string"
+    },
+    "messages": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          },
+          "content": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "input": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                  }
+                },
+                "output": {
+                  "type": "string"
+                },
+                "is_error": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "tools": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "input_schema": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          }
+        },
+        "required": [
+          "name",
+          "input_schema"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "context": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "agent_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "channel_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stream_id": {
+      "type": "string"
+    }
+  },
+  "title": "ProviderCreateMessageParams",
+  "required": [
+    "model",
+    "max_tokens",
+    "messages"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderCreateMessageResult.json
+++ b/schemas/ProviderCreateMessageResult.json
@@ -1,0 +1,64 @@
+{
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "input": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "output": {
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "stop_reason": {
+      "type": "string"
+    },
+    "input_tokens": {
+      "type": "integer"
+    },
+    "output_tokens": {
+      "type": "integer"
+    }
+  },
+  "title": "ProviderCreateMessageResult",
+  "required": [
+    "content",
+    "stop_reason"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderDef.json
+++ b/schemas/ProviderDef.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "title": "ProviderDef",
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderMessage.json
+++ b/schemas/ProviderMessage.json
@@ -1,0 +1,58 @@
+{
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string"
+    },
+    "content": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "input": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          },
+          "output": {
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "ProviderMessage",
+  "required": [
+    "role",
+    "content"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ProviderToolDef.json
+++ b/schemas/ProviderToolDef.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "input_schema": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "title": "ProviderToolDef",
+  "required": [
+    "name",
+    "input_schema"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/RPCError.json
+++ b/schemas/RPCError.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "integer"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "title": "RPCError",
+  "required": [
+    "code",
+    "message"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/Registrations.json
+++ b/schemas/Registrations.json
@@ -1,0 +1,185 @@
+{
+  "type": "object",
+  "properties": {
+    "tools": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "input_schema": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "input_schema"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "http_routes": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "methods": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "path",
+          "methods"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "hooks": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "matcher": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "events"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "services": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "providers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "tts_providers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "cli_commands": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "args": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "Registrations",
+  "additionalProperties": false
+}

--- a/schemas/Request.json
+++ b/schemas/Request.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "jsonrpc": {
+      "type": "string"
+    },
+    "method": {
+      "type": "string"
+    },
+    "params": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    },
+    "id": {
+      "type": "integer"
+    }
+  },
+  "title": "Request",
+  "required": [
+    "jsonrpc",
+    "method",
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/Response.json
+++ b/schemas/Response.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "jsonrpc": {
+      "type": "string"
+    },
+    "result": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    },
+    "error": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "additionalProperties": false
+    },
+    "id": {
+      "type": "integer"
+    }
+  },
+  "title": "Response",
+  "required": [
+    "jsonrpc",
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceDef.json
+++ b/schemas/ServiceDef.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "title": "ServiceDef",
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceHealthParams.json
+++ b/schemas/ServiceHealthParams.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "ServiceHealthParams",
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceHealthResult.json
+++ b/schemas/ServiceHealthResult.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "title": "ServiceHealthResult",
+  "required": [
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceStartParams.json
+++ b/schemas/ServiceStartParams.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "title": "ServiceStartParams",
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceStartResult.json
+++ b/schemas/ServiceStartResult.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    }
+  },
+  "title": "ServiceStartResult",
+  "required": [
+    "ok"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceStopParams.json
+++ b/schemas/ServiceStopParams.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "ServiceStopParams",
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ServiceStopResult.json
+++ b/schemas/ServiceStopResult.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    }
+  },
+  "title": "ServiceStopResult",
+  "required": [
+    "ok"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/StreamChunkParams.json
+++ b/schemas/StreamChunkParams.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "stream_id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "tool_id": {
+      "type": "string"
+    },
+    "tool_name": {
+      "type": "string"
+    },
+    "tool_input": {
+      "type": "string"
+    },
+    "index": {
+      "type": "integer"
+    }
+  },
+  "title": "StreamChunkParams",
+  "required": [
+    "stream_id",
+    "type",
+    "index"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/StreamEndParams.json
+++ b/schemas/StreamEndParams.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "stream_id": {
+      "type": "string"
+    },
+    "total_chunks": {
+      "type": "integer"
+    }
+  },
+  "title": "StreamEndParams",
+  "required": [
+    "stream_id",
+    "total_chunks"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/StreamErrorParams.json
+++ b/schemas/StreamErrorParams.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "stream_id": {
+      "type": "string"
+    },
+    "code": {
+      "type": "integer"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "title": "StreamErrorParams",
+  "required": [
+    "stream_id",
+    "code",
+    "message"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/TTSProviderDef.json
+++ b/schemas/TTSProviderDef.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "title": "TTSProviderDef",
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/TTSSynthesizeParams.json
+++ b/schemas/TTSSynthesizeParams.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "voice": {
+      "type": "string"
+    },
+    "model": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string"
+    },
+    "speed": {
+      "type": "number"
+    }
+  },
+  "title": "TTSSynthesizeParams",
+  "required": [
+    "text",
+    "voice"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/TTSSynthesizeResult.json
+++ b/schemas/TTSSynthesizeResult.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "audio_base64": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string"
+    },
+    "content_type": {
+      "type": "string"
+    }
+  },
+  "title": "TTSSynthesizeResult",
+  "required": [
+    "audio_base64",
+    "format",
+    "content_type"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/TTSVoice.json
+++ b/schemas/TTSVoice.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "title": "TTSVoice",
+  "required": [
+    "id",
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/TTSVoicesResult.json
+++ b/schemas/TTSVoicesResult.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "voices": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "TTSVoicesResult",
+  "required": [
+    "voices"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ToolCallParams.json
+++ b/schemas/ToolCallParams.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "context": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "agent_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "channel_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "title": "ToolCallParams",
+  "required": [
+    "name",
+    "input"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ToolCallResult.json
+++ b/schemas/ToolCallResult.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "output": {
+      "type": "string"
+    },
+    "is_error": {
+      "type": "boolean"
+    }
+  },
+  "title": "ToolCallResult",
+  "required": [
+    "output",
+    "is_error"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/ToolDef.json
+++ b/schemas/ToolDef.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "input_schema": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "title": "ToolDef",
+  "required": [
+    "name",
+    "description",
+    "input_schema"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -1,0 +1,215 @@
+package schemas_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/kova-land/extension-sdk-go/protocol"
+)
+
+func allProtocolTypes() map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"Request":                     reflect.TypeOf(protocol.Request{}),
+		"Response":                    reflect.TypeOf(protocol.Response{}),
+		"Notification":                reflect.TypeOf(protocol.Notification{}),
+		"RPCError":                    reflect.TypeOf(protocol.RPCError{}),
+		"InitializeParams":            reflect.TypeOf(protocol.InitializeParams{}),
+		"InitializeResult":            reflect.TypeOf(protocol.InitializeResult{}),
+		"Registrations":               reflect.TypeOf(protocol.Registrations{}),
+		"ToolDef":                     reflect.TypeOf(protocol.ToolDef{}),
+		"HTTPRouteDef":                reflect.TypeOf(protocol.HTTPRouteDef{}),
+		"HookDef":                     reflect.TypeOf(protocol.HookDef{}),
+		"ServiceDef":                  reflect.TypeOf(protocol.ServiceDef{}),
+		"ProviderDef":                 reflect.TypeOf(protocol.ProviderDef{}),
+		"TTSProviderDef":              reflect.TypeOf(protocol.TTSProviderDef{}),
+		"CLIDef":                      reflect.TypeOf(protocol.CLIDef{}),
+		"CallContext":                 reflect.TypeOf(protocol.CallContext{}),
+		"ToolCallParams":              reflect.TypeOf(protocol.ToolCallParams{}),
+		"ToolCallResult":              reflect.TypeOf(protocol.ToolCallResult{}),
+		"ChannelMessageParams":        reflect.TypeOf(protocol.ChannelMessageParams{}),
+		"ChannelMessageImage":         reflect.TypeOf(protocol.ChannelMessageImage{}),
+		"ChannelSendParams":           reflect.TypeOf(protocol.ChannelSendParams{}),
+		"ChannelSendAttachment":       reflect.TypeOf(protocol.ChannelSendAttachment{}),
+		"ChannelSendComponent":        reflect.TypeOf(protocol.ChannelSendComponent{}),
+		"ChannelTypingParams":         reflect.TypeOf(protocol.ChannelTypingParams{}),
+		"ChannelReactionAddParams":    reflect.TypeOf(protocol.ChannelReactionAddParams{}),
+		"ChannelReactionRemoveParams": reflect.TypeOf(protocol.ChannelReactionRemoveParams{}),
+		"PromptOption":                reflect.TypeOf(protocol.PromptOption{}),
+		"PromptUserParams":            reflect.TypeOf(protocol.PromptUserParams{}),
+		"PromptUserResult":            reflect.TypeOf(protocol.PromptUserResult{}),
+		"ChannelCapabilities":         reflect.TypeOf(protocol.ChannelCapabilities{}),
+		"ChannelCapabilitiesParams":   reflect.TypeOf(protocol.ChannelCapabilitiesParams{}),
+		"ChannelCapabilitiesResult":   reflect.TypeOf(protocol.ChannelCapabilitiesResult{}),
+		"HookEventParams":             reflect.TypeOf(protocol.HookEventParams{}),
+		"HookEventResult":             reflect.TypeOf(protocol.HookEventResult{}),
+		"HTTPRequestParams":           reflect.TypeOf(protocol.HTTPRequestParams{}),
+		"HTTPResponseResult":          reflect.TypeOf(protocol.HTTPResponseResult{}),
+		"ServiceStartParams":          reflect.TypeOf(protocol.ServiceStartParams{}),
+		"ServiceStartResult":          reflect.TypeOf(protocol.ServiceStartResult{}),
+		"ServiceHealthParams":         reflect.TypeOf(protocol.ServiceHealthParams{}),
+		"ServiceHealthResult":         reflect.TypeOf(protocol.ServiceHealthResult{}),
+		"ServiceStopParams":           reflect.TypeOf(protocol.ServiceStopParams{}),
+		"ServiceStopResult":           reflect.TypeOf(protocol.ServiceStopResult{}),
+		"ProviderContentBlock":        reflect.TypeOf(protocol.ProviderContentBlock{}),
+		"ProviderMessage":             reflect.TypeOf(protocol.ProviderMessage{}),
+		"ProviderToolDef":             reflect.TypeOf(protocol.ProviderToolDef{}),
+		"ProviderCreateMessageParams": reflect.TypeOf(protocol.ProviderCreateMessageParams{}),
+		"ProviderCreateMessageResult": reflect.TypeOf(protocol.ProviderCreateMessageResult{}),
+		"StreamChunkParams":           reflect.TypeOf(protocol.StreamChunkParams{}),
+		"StreamEndParams":             reflect.TypeOf(protocol.StreamEndParams{}),
+		"StreamErrorParams":           reflect.TypeOf(protocol.StreamErrorParams{}),
+		"ProviderCapabilitiesParams":  reflect.TypeOf(protocol.ProviderCapabilitiesParams{}),
+		"ProviderCapabilitiesResult":  reflect.TypeOf(protocol.ProviderCapabilitiesResult{}),
+		"TTSSynthesizeParams":         reflect.TypeOf(protocol.TTSSynthesizeParams{}),
+		"TTSSynthesizeResult":         reflect.TypeOf(protocol.TTSSynthesizeResult{}),
+		"TTSVoicesResult":             reflect.TypeOf(protocol.TTSVoicesResult{}),
+		"TTSVoice":                    reflect.TypeOf(protocol.TTSVoice{}),
+		"LogParams":                   reflect.TypeOf(protocol.LogParams{}),
+	}
+}
+
+func TestSchemaFilesExist(t *testing.T) {
+	for name := range allProtocolTypes() {
+		filename := name + ".json"
+		path := filepath.Join(".", filename)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("missing schema file for %s: %s", name, path)
+		}
+	}
+}
+
+func TestSchemaFilesAreValidJSON(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read schemas dir: %v", err)
+	}
+
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		t.Run(entry.Name(), func(t *testing.T) {
+			data, err := os.ReadFile(entry.Name())
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			var schema map[string]any
+			if err := json.Unmarshal(data, &schema); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+
+			if _, ok := schema["type"]; !ok {
+				t.Error("schema missing 'type' field")
+			}
+
+			title, ok := schema["title"]
+			if !ok {
+				t.Error("schema missing 'title' field")
+			}
+
+			expected := strings.TrimSuffix(entry.Name(), ".json")
+			if title != expected {
+				t.Errorf("title mismatch: got %q, want %q", title, expected)
+			}
+		})
+	}
+}
+
+func TestSchemasMatchTypes(t *testing.T) {
+	opts := &jsonschema.ForOptions{
+		IgnoreInvalidTypes: true,
+	}
+
+	for name, typ := range allProtocolTypes() {
+		t.Run(name, func(t *testing.T) {
+			freshSchema, err := jsonschema.ForType(typ, opts)
+			if err != nil {
+				t.Fatalf("ForType(%s): %v", name, err)
+			}
+
+			freshData, err := json.Marshal(freshSchema)
+			if err != nil {
+				t.Fatalf("marshal fresh schema: %v", err)
+			}
+
+			filename := filepath.Join(".", name+".json")
+			fileData, err := os.ReadFile(filename)
+			if err != nil {
+				t.Fatalf("read schema file: %v", err)
+			}
+
+			var freshMap, fileMap map[string]any
+			if err := json.Unmarshal(freshData, &freshMap); err != nil {
+				t.Fatalf("unmarshal fresh: %v", err)
+			}
+			if err := json.Unmarshal(fileData, &fileMap); err != nil {
+				t.Fatalf("unmarshal file: %v", err)
+			}
+
+			freshProps := extractPropertyNames(freshMap)
+			fileProps := extractPropertyNames(fileMap)
+
+			for _, p := range freshProps {
+				if !contains(fileProps, p) {
+					t.Errorf("property %q in Go type but missing from schema file", p)
+				}
+			}
+			for _, p := range fileProps {
+				if !contains(freshProps, p) {
+					t.Errorf("property %q in schema file but missing from Go type", p)
+				}
+			}
+		})
+	}
+}
+
+func TestNoExtraSchemaFiles(t *testing.T) {
+	types := allProtocolTypes()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read schemas dir: %v", err)
+	}
+
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		if _, ok := types[name]; !ok {
+			t.Errorf("schema file %s has no corresponding protocol type", entry.Name())
+		}
+	}
+}
+
+func extractPropertyNames(schema map[string]any) []string {
+	props, ok := schema["properties"]
+	if !ok {
+		return nil
+	}
+	propsMap, ok := props.(map[string]any)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(propsMap))
+	for k := range propsMap {
+		names = append(names, k)
+	}
+	return names
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `cmd/generate-schemas/` using `google/jsonschema-go` to reflect on all 56 protocol types and output JSON Schema files to `schemas/`
- Add `go:generate` directive in `protocol/doc.go` and `Makefile` target (`make generate`) for easy regeneration
- Add comprehensive tests (`schemas/schemas_test.go`) verifying schema file existence, JSON validity, type-property alignment, and no orphaned schema files

## Test plan
- [x] `go test -v ./...` passes (all existing + new schema tests)
- [x] `go vet ./...` clean
- [x] Generated schemas validated against Go types via `TestSchemasMatchTypes`
- [ ] CI passes on push

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)