### PR TITLE
fix: address SDK review findings — README accuracy, init error test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go SDK for building [Kova](https://github.com/kova-land/kova) extensions. Provid
 go get github.com/kova-land/extension-sdk-go
 ```
 
-**Zero external dependencies** -- the SDK uses only the Go standard library.
+Core packages (`protocol`, `jsonrpc`, `extension`, `harness`) have zero external dependencies and use only the Go standard library. The `schemas` package uses `github.com/google/jsonschema-go` for schema generation.
 
 ## Package Overview
 
@@ -98,6 +98,10 @@ Bridges a text-to-speech API (OpenAI TTS, Piper, etc.) to kova. Implement `exten
 ```go
 extension.RunTTS(&myTTS{})
 ```
+
+### Multi-Type Limitation
+
+Each `Run*` function handles a single registration type. Extensions that register multiple types (e.g., both tools and hooks) are not yet supported by the SDK — use the low-level `jsonrpc.Transport` directly for multi-type extensions.
 
 ## Testing Extensions
 

--- a/extension/channel_errors_test.go
+++ b/extension/channel_errors_test.go
@@ -177,6 +177,24 @@ func TestRunChannel_CapabilitiesError(t *testing.T) {
 	fk.Shutdown()
 }
 
+func TestRunChannel_InitializeError(t *testing.T) {
+	ext := &errorChannelExt{initErr: errors.New("init failed")}
+	fk := runChannelExt(t, ext)
+
+	rpcErr := fk.CallExpectError(protocol.MethodInitialize, protocol.InitializeParams{
+		Config:        map[string]any{},
+		ExtensionRoot: t.TempDir(),
+	})
+	if rpcErr.Code != protocol.ErrCodeNotReady {
+		t.Errorf("code = %d, want %d (ErrCodeNotReady)", rpcErr.Code, protocol.ErrCodeNotReady)
+	}
+	if rpcErr.Message != "init failed" {
+		t.Errorf("message = %q, want %q", rpcErr.Message, "init failed")
+	}
+
+	fk.Shutdown()
+}
+
 func TestRunChannel_UnknownMethod(t *testing.T) {
 	ext := &fakeChannelExt{}
 	fk := runChannelExt(t, ext)


### PR DESCRIPTION
## Summary

- **Issue 2 (README false claim)**: Replaced the blanket "zero external dependencies" claim with an accurate statement: core packages (`protocol`, `jsonrpc`, `extension`, `harness`) have no external dependencies, but the `schemas` package uses `github.com/google/jsonschema-go`.
- **Issue 3 (multi-type extension limitation)**: Added a "Multi-Type Limitation" note under Extension Types documenting that each `Run*` function handles only one registration type, and directing users to `jsonrpc.Transport` for multi-type extensions.
- **Issue 4 (init error path untested)**: Added `TestRunChannel_InitializeError` to `extension/channel_errors_test.go`, using the existing `errorChannelExt.initErr` field to verify that `initialize` returns `ErrCodeNotReady` when `Initialize()` returns an error.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] New test `TestRunChannel_InitializeError` exercises the `ErrCodeNotReady` response path and verifies both the error code and message

🤖 Generated with [Claude Code](https://claude.com/claude-code)