### PR TITLE
feat: JSON schema generation CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,20 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+  schemas:
+    name: Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Validate schemas are up-to-date
+        run: make check-schemas
+
   security:
     name: Go Security
     runs-on: ubuntu-latest
@@ -82,12 +96,12 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [test, lint, vet, security]
+    needs: [test, lint, vet, schemas, security]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          results=("${{ needs.test.result }}" "${{ needs.lint.result }}" "${{ needs.vet.result }}" "${{ needs.security.result }}")
+          results=("${{ needs.test.result }}" "${{ needs.lint.result }}" "${{ needs.vet.result }}" "${{ needs.schemas.result }}" "${{ needs.security.result }}")
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
               echo "One or more jobs failed or were cancelled"

--- a/.github/workflows/generate-schemas.yml
+++ b/.github/workflows/generate-schemas.yml
@@ -1,0 +1,51 @@
+name: Generate Schemas
+
+run-name: "Generate Schemas: ${{ github.ref_name }}"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'protocol/**'
+      - 'cmd/generate-schemas/**'
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    name: Update Schemas
+    runs-on: ubuntu-latest
+    # Skip commits from this workflow to avoid infinite loops
+    if: "!startsWith(github.event.head_commit.message, 'chore: update generated schemas')"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate schemas
+        run: make generate
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet schemas/; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Schemas are up-to-date"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Schema changes detected:"
+            git diff --stat schemas/
+          fi
+
+      - name: Commit updated schemas
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add schemas/
+          git commit -m "chore: update generated schemas"
+          git push

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: generate test vet
+.PHONY: generate check-schemas test vet lint
 
 generate: ## Regenerate JSON schemas from Go protocol types
 	go run ./cmd/generate-schemas/
+
+check-schemas: ## Validate committed schemas match Go types (CI use)
+	go run ./cmd/generate-schemas/ --check
 
 test: ## Run all tests
 	go test -v ./...
 
 vet: ## Run go vet
 	go vet ./...
+
+lint: ## Run golangci-lint
+	golangci-lint run ./...

--- a/cmd/generate-schemas/main.go
+++ b/cmd/generate-schemas/main.go
@@ -1,9 +1,15 @@
 // Command generate-schemas reflects on the protocol package types and writes
 // JSON Schema files to the schemas/ directory.
+//
+// Flags:
+//
+//	--check  Validate that committed schemas are up-to-date (exit 1 on drift).
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -16,6 +22,9 @@ import (
 )
 
 func main() {
+	check := flag.Bool("check", false, "validate schemas are up-to-date without writing")
+	flag.Parse()
+
 	types := []any{
 		protocol.Request{},
 		protocol.Response{},
@@ -84,7 +93,10 @@ func main() {
 		IgnoreInvalidTypes: true,
 	}
 
-	var errors []string
+	var (
+		errors []string
+		drifts []string
+	)
 
 	for _, instance := range types {
 		t := reflect.TypeOf(instance)
@@ -108,6 +120,19 @@ func main() {
 		data = append(data, '\n')
 
 		outPath := filepath.Join(outDir, filename)
+
+		if *check {
+			existing, err := os.ReadFile(outPath)
+			if err != nil {
+				drifts = append(drifts, fmt.Sprintf("%s: %v", filename, err))
+				continue
+			}
+			if !bytes.Equal(data, existing) {
+				drifts = append(drifts, filename)
+			}
+			continue
+		}
+
 		if err := os.WriteFile(outPath, data, 0o644); err != nil {
 			errors = append(errors, fmt.Sprintf("%s: write: %v", filename, err))
 			continue
@@ -120,6 +145,18 @@ func main() {
 			log.Printf("ERROR: %s", e)
 		}
 		os.Exit(1)
+	}
+
+	if *check {
+		if len(drifts) > 0 {
+			fmt.Fprintf(os.Stderr, "schemas are out of date — run 'make generate' and commit:\n")
+			for _, d := range drifts {
+				fmt.Fprintf(os.Stderr, "  %s\n", d)
+			}
+			os.Exit(1)
+		}
+		fmt.Printf("All %d schemas are up-to-date\n", len(types))
+		return
 	}
 
 	fmt.Printf("\nGenerated %d schemas in %s/\n", len(types), outDir)

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -133,11 +133,14 @@ func TestSchemasMatchTypes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ForType(%s): %v", name, err)
 			}
+			freshSchema.Title = name
 
-			freshData, err := json.Marshal(freshSchema)
+			// Generate the same output the generator would write.
+			freshData, err := json.MarshalIndent(freshSchema, "", "  ")
 			if err != nil {
 				t.Fatalf("marshal fresh schema: %v", err)
 			}
+			freshData = append(freshData, '\n')
 
 			filename := filepath.Join(".", name+".json")
 			fileData, err := os.ReadFile(filename)
@@ -145,26 +148,8 @@ func TestSchemasMatchTypes(t *testing.T) {
 				t.Fatalf("read schema file: %v", err)
 			}
 
-			var freshMap, fileMap map[string]any
-			if err := json.Unmarshal(freshData, &freshMap); err != nil {
-				t.Fatalf("unmarshal fresh: %v", err)
-			}
-			if err := json.Unmarshal(fileData, &fileMap); err != nil {
-				t.Fatalf("unmarshal file: %v", err)
-			}
-
-			freshProps := extractPropertyNames(freshMap)
-			fileProps := extractPropertyNames(fileMap)
-
-			for _, p := range freshProps {
-				if !contains(fileProps, p) {
-					t.Errorf("property %q in Go type but missing from schema file", p)
-				}
-			}
-			for _, p := range fileProps {
-				if !contains(freshProps, p) {
-					t.Errorf("property %q in schema file but missing from Go type", p)
-				}
+			if string(freshData) != string(fileData) {
+				t.Errorf("schema file is out of date — run 'make generate' and commit")
 			}
 		})
 	}
@@ -187,29 +172,4 @@ func TestNoExtraSchemaFiles(t *testing.T) {
 			t.Errorf("schema file %s has no corresponding protocol type", entry.Name())
 		}
 	}
-}
-
-func extractPropertyNames(schema map[string]any) []string {
-	props, ok := schema["properties"]
-	if !ok {
-		return nil
-	}
-	propsMap, ok := props.(map[string]any)
-	if !ok {
-		return nil
-	}
-	names := make([]string, 0, len(propsMap))
-	for k := range propsMap {
-		names = append(names, k)
-	}
-	return names
-}
-
-func contains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- Add `--check` flag to `cmd/generate-schemas` for CI validation (exits non-zero on drift without writing)
- Add dedicated **Schemas** job to CI workflow that validates committed schemas match Go types on every push/PR
- Add **Generate Schemas** workflow that auto-commits updated schemas on push to main when `protocol/` or `cmd/generate-schemas/` files change
- Strengthen `TestSchemasMatchTypes` to do full byte-level content comparison (was only checking property names)
- Add `make check-schemas` and `make lint` targets

Closes kova-land/kova#707

## Test plan
- [x] `make check-schemas` passes (validates all 56 schemas are up-to-date)
- [x] `go test -v -race ./...` passes (all tests green)
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] CI Schemas job passes on this PR
- [ ] Verify generate-schemas workflow triggers on main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)