### PR TITLE
feat: add cache token fields to Response Usage

### DIFF
--- a/protocol/provider.go
+++ b/protocol/provider.go
@@ -61,6 +61,10 @@ type ProviderCreateMessageResult struct {
 	InputTokens int64 `json:"input_tokens,omitempty"`
 	// OutputTokens is the number of output tokens generated.
 	OutputTokens int64 `json:"output_tokens,omitempty"`
+	// CacheReadTokens is the number of input tokens read from the prompt cache.
+	CacheReadTokens int64 `json:"cache_read_tokens,omitempty"`
+	// CacheCreateTokens is the number of input tokens written to the prompt cache.
+	CacheCreateTokens int64 `json:"cache_create_tokens,omitempty"`
 }
 
 // StreamChunkParams is the payload for a "stream_chunk" notification.

--- a/schemas/ProviderCreateMessageResult.json
+++ b/schemas/ProviderCreateMessageResult.json
@@ -53,6 +53,12 @@
     },
     "output_tokens": {
       "type": "integer"
+    },
+    "cache_read_tokens": {
+      "type": "integer"
+    },
+    "cache_create_tokens": {
+      "type": "integer"
     }
   },
   "title": "ProviderCreateMessageResult",


### PR DESCRIPTION
## Summary
- Add `CacheReadTokens` and `CacheCreateTokens` fields to `ProviderCreateMessageResult` in the protocol package
- Regenerate JSON schemas to include the new fields
- Enables extension providers (e.g., Anthropic) to report prompt cache hit/miss token counts for cost tracking

## Downstream
- **kova core**: Will wire these fields through `BridgeProvider.fromProtocolResult()` to internal `provider.Response` (separate PR)
- **Python/TypeScript SDKs**: Need their types regenerated from the updated schemas after this merges

## Test plan
- [x] `go test ./...` passes
- [x] `make check-schemas` validates generated schemas match Go types
- [ ] Verify kova BridgeProvider correctly maps the new fields (downstream PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)