### PR TITLE
chore: enable Go module caching in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Validate module
         if: steps.bump.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- Add `cache: true` to `actions/setup-go@v6` in the release workflow to cache Go module downloads between CI runs
- No CI workflow exists (`ci.yml`), so only the release workflow needed updating

## Test plan
- [ ] Verify release workflow runs successfully with caching enabled
- [ ] Check that subsequent runs show cache hits in the setup-go step