### PR TITLE
feat: add media format and capability fields to ChannelCapabilities

### DIFF
--- a/protocol/channel.go
+++ b/protocol/channel.go
@@ -208,8 +208,30 @@ type ChannelCapabilities struct {
 	SupportsThreads   bool `json:"supports_threads,omitempty"`
 	SupportsDMs       bool `json:"supports_dms,omitempty"`
 	SupportsMentions  bool `json:"supports_mentions,omitempty"`
+	// SupportsMarkdown indicates the platform renders markdown formatting in messages.
+	SupportsMarkdown bool `json:"supports_markdown,omitempty"`
+	// SupportsNativeCommands indicates the platform has native slash-command support
+	// (e.g. Discord interactions).
+	SupportsNativeCommands bool `json:"supports_native_commands,omitempty"`
+	// SupportsTextCommands indicates the platform supports text-prefix commands
+	// (e.g. /help sent as a plain message).
+	SupportsTextCommands bool `json:"supports_text_commands,omitempty"`
 	// MaxMessageLen is the platform's maximum message length. 0 means unlimited.
 	MaxMessageLen int `json:"max_message_len,omitempty"`
+	// MaxFileSize is the platform's maximum attachment size in bytes. 0 means
+	// unlimited or unknown.
+	MaxFileSize int64 `json:"max_file_size,omitempty"`
+	// AudioFormats lists the audio container/codec formats the platform accepts
+	// (e.g. ["opus", "mp3", "ogg"]). Empty means any format is accepted or audio
+	// is not supported.
+	AudioFormats []string `json:"audio_formats,omitempty"`
+	// ImageFormats lists the image formats the platform accepts (e.g. ["png",
+	// "jpg", "webp", "gif"]). Empty means any format is accepted or images are
+	// not supported.
+	ImageFormats []string `json:"image_formats,omitempty"`
+	// FormattingHints provides platform-specific formatting guidance for the agent
+	// (e.g. ["no_bold", "max_embeds:1"]). Empty means no special hints.
+	FormattingHints []string `json:"formatting_hints,omitempty"`
 }
 
 // ChannelCapabilitiesParams is sent by kova to query the extension's platform

--- a/schemas/ChannelCapabilities.json
+++ b/schemas/ChannelCapabilities.json
@@ -37,8 +37,47 @@
     "supports_mentions": {
       "type": "boolean"
     },
+    "supports_markdown": {
+      "type": "boolean"
+    },
+    "supports_native_commands": {
+      "type": "boolean"
+    },
+    "supports_text_commands": {
+      "type": "boolean"
+    },
     "max_message_len": {
       "type": "integer"
+    },
+    "max_file_size": {
+      "type": "integer"
+    },
+    "audio_formats": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "image_formats": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "formatting_hints": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "title": "ChannelCapabilities",

--- a/schemas/ChannelCapabilitiesResult.json
+++ b/schemas/ChannelCapabilitiesResult.json
@@ -40,8 +40,47 @@
         "supports_mentions": {
           "type": "boolean"
         },
+        "supports_markdown": {
+          "type": "boolean"
+        },
+        "supports_native_commands": {
+          "type": "boolean"
+        },
+        "supports_text_commands": {
+          "type": "boolean"
+        },
         "max_message_len": {
           "type": "integer"
+        },
+        "max_file_size": {
+          "type": "integer"
+        },
+        "audio_formats": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "image_formats": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "formatting_hints": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Closes #16

## Summary

- Adds `AudioFormats []string`, `ImageFormats []string`, `MaxFileSize int64`, `SupportsMarkdown bool`, `SupportsNativeCommands bool`, `SupportsTextCommands bool`, and `FormattingHints []string` to `ChannelCapabilities`
- Regenerates `schemas/ChannelCapabilities.json` and `schemas/ChannelCapabilitiesResult.json` via `make generate`
- All fields are `omitempty` — fully backwards compatible

## Follow-up

kova's `subprocess_channel.go` bridge mapping needs updating to pass these new fields through from the internal `Capabilities` struct. Tracked as a follow-up in kova.