### PR TITLE
feat: add ProtocolVersion to InitializeResult

### DIFF
--- a/protocol/initialize.go
+++ b/protocol/initialize.go
@@ -15,7 +15,11 @@ type InitializeParams struct {
 
 // InitializeResult is the response payload for the "initialize" request.
 type InitializeResult struct {
-	Registrations Registrations `json:"registrations"`
+	// ProtocolVersion is the extension protocol version this extension
+	// implements (e.g. "0.5"). When set, kova validates compatibility.
+	// Omit or leave empty to skip version negotiation.
+	ProtocolVersion string        `json:"protocol_version,omitempty"`
+	Registrations   Registrations `json:"registrations"`
 }
 
 // Registrations holds all integration points an extension declares during

--- a/schemas/InitializeResult.json
+++ b/schemas/InitializeResult.json
@@ -1,6 +1,9 @@
 {
   "type": "object",
   "properties": {
+    "protocol_version": {
+      "type": "string"
+    },
     "registrations": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary

- Extensions currently need a local struct embed to report `protocol_version` back to kova on initialization
- Added `ProtocolVersion string` field (`json:"protocol_version,omitempty"`) to `InitializeResult` so extensions can set it directly
- Regenerated `schemas/InitializeResult.json` to include the new optional field

## Test plan

- [ ] `go test ./...` passes (all 5 test packages green)
- [ ] `make check-schemas` passes (schemas match Go types)
- [ ] Extensions can set `InitializeResult{ProtocolVersion: "0.5", Registrations: ...}` without local struct embedding