### PR TITLE
feat: add STT provider types for speech-to-text extensions

### DIFF
--- a/cmd/generate-schemas/main.go
+++ b/cmd/generate-schemas/main.go
@@ -81,6 +81,12 @@ func main() {
 		protocol.TTSSynthesizeResult{},
 		protocol.TTSVoicesResult{},
 		protocol.TTSVoice{},
+		protocol.STTProviderDef{},
+		protocol.STTTranscribeParams{},
+		protocol.STTTranscribeResult{},
+		protocol.STTSegment{},
+		protocol.STTModelsResult{},
+		protocol.STTModel{},
 		protocol.LogParams{},
 	}
 

--- a/extension/run.go
+++ b/extension/run.go
@@ -16,6 +16,7 @@ type compositeConfig struct {
 	provider ProviderExtension
 	tool     ToolExtension
 	tts      TTSExtension
+	stt      STTExtension
 	hook     HookExtension
 	http     HTTPExtension
 	service  ServiceExtension
@@ -39,6 +40,11 @@ func WithTool(ext ToolExtension) RunOption {
 // WithTTS registers a TTS extension handler.
 func WithTTS(ext TTSExtension) RunOption {
 	return func(c *compositeConfig) { c.tts = ext }
+}
+
+// WithSTT registers an STT extension handler.
+func WithSTT(ext STTExtension) RunOption {
+	return func(c *compositeConfig) { c.stt = ext }
 }
 
 // WithHook registers a hook extension handler.
@@ -133,6 +139,13 @@ func compositeInitialize(cc *compositeConfig, emitter *Emitter, params protocol.
 		}
 		mergeRegistrations(merged, regs)
 	}
+	if cc.stt != nil {
+		regs, err := cc.stt.Initialize(emitter, params.Config, params.ExtensionRoot)
+		if err != nil {
+			return nil, fmt.Errorf("stt init: %w", err)
+		}
+		mergeRegistrations(merged, regs)
+	}
 	if cc.hook != nil {
 		regs, err := cc.hook.Initialize(emitter, params.Config, params.ExtensionRoot)
 		if err != nil {
@@ -169,6 +182,7 @@ func mergeRegistrations(dst, src *protocol.Registrations) {
 	dst.Services = append(dst.Services, src.Services...)
 	dst.Providers = append(dst.Providers, src.Providers...)
 	dst.TTSProviders = append(dst.TTSProviders, src.TTSProviders...)
+	dst.STTProviders = append(dst.STTProviders, src.STTProviders...)
 	dst.CLICommands = append(dst.CLICommands, src.CLICommands...)
 }
 
@@ -201,6 +215,12 @@ func compositeDispatch(ctx context.Context, t *jsonrpc.Transport, cc *compositeC
 	case protocol.MethodTTSSynthesize, protocol.MethodTTSVoices:
 		if cc.tts != nil {
 			return dispatchTTS(ctx, t, cc.tts, req)
+		}
+
+	// STT methods
+	case protocol.MethodSTTTranscribe, protocol.MethodSTTModels:
+		if cc.stt != nil {
+			return dispatchSTT(ctx, t, cc.stt, req)
 		}
 
 	// Hook methods
@@ -247,6 +267,11 @@ func compositeShutdown(cc *compositeConfig) error {
 	if cc.tts != nil {
 		if err := cc.tts.Shutdown(); err != nil {
 			errs = append(errs, fmt.Errorf("tts shutdown: %w", err))
+		}
+	}
+	if cc.stt != nil {
+		if err := cc.stt.Shutdown(); err != nil {
+			errs = append(errs, fmt.Errorf("stt shutdown: %w", err))
 		}
 	}
 	if cc.hook != nil {

--- a/extension/stt.go
+++ b/extension/stt.go
@@ -1,0 +1,65 @@
+package extension
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kova-land/extension-sdk-go/jsonrpc"
+	"github.com/kova-land/extension-sdk-go/protocol"
+)
+
+// STTExtension is the interface that an STT (speech-to-text) provider extension
+// implements. STT extensions bridge a speech recognition API (OpenAI Whisper,
+// Deepgram, etc.) to kova's audio pipeline.
+type STTExtension interface {
+	// Initialize is called when the host sends the "initialize" request.
+	// The extension should set up its STT client and return registrations
+	// declaring the STT provider(s) it offers.
+	Initialize(emitter *Emitter, config map[string]any, extensionRoot string) (*protocol.Registrations, error)
+
+	// HandleTranscribe processes a speech-to-text transcription request and
+	// returns the recognized text.
+	HandleTranscribe(ctx context.Context, params protocol.STTTranscribeParams) (*protocol.STTTranscribeResult, error)
+
+	// HandleModels returns the list of available STT models.
+	HandleModels(ctx context.Context) (*protocol.STTModelsResult, error)
+
+	// Shutdown is called when the host sends the "shutdown" request.
+	Shutdown() error
+}
+
+// RunSTT starts the JSON-RPC event loop for an STT extension. It handles
+// the initialize/shutdown lifecycle and dispatches STT-specific methods to
+// the provided implementation. This function blocks until the host closes
+// stdin, sends "shutdown", or an OS signal is received.
+//
+// This is a convenience wrapper around [Run] with [WithSTT].
+func RunSTT(ext STTExtension, opts ...Option) error {
+	return Run([]RunOption{WithSTT(ext)}, opts...)
+}
+
+func dispatchSTT(ctx context.Context, t *jsonrpc.Transport, ext STTExtension, req *protocol.Request) error {
+	switch req.Method {
+	case protocol.MethodSTTTranscribe:
+		var params protocol.STTTranscribeParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return t.SendError(req.ID, protocol.ErrCodeInvalidParams, fmt.Sprintf("invalid params: %v", err))
+		}
+		result, err := ext.HandleTranscribe(ctx, params)
+		if err != nil {
+			return t.SendError(req.ID, protocol.ErrCodeSTTFailed, err.Error())
+		}
+		return t.SendResponse(req.ID, result)
+
+	case protocol.MethodSTTModels:
+		result, err := ext.HandleModels(ctx)
+		if err != nil {
+			return t.SendError(req.ID, protocol.ErrCodeSTTFailed, err.Error())
+		}
+		return t.SendResponse(req.ID, result)
+
+	default:
+		return t.SendError(req.ID, protocol.ErrCodeMethodNotFound, fmt.Sprintf("unknown method: %s", req.Method))
+	}
+}

--- a/extension/stt_test.go
+++ b/extension/stt_test.go
@@ -1,0 +1,183 @@
+package extension_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kova-land/extension-sdk-go/extension"
+	"github.com/kova-land/extension-sdk-go/harness"
+	"github.com/kova-land/extension-sdk-go/protocol"
+)
+
+// fakeSTTExt is a minimal STTExtension for testing.
+type fakeSTTExt struct {
+	sttProviders     []protocol.STTProviderDef
+	transcribeResult *protocol.STTTranscribeResult
+	transcribeErr    error
+	modelsResult     *protocol.STTModelsResult
+	modelsErr        error
+	shutdownCalled   bool
+}
+
+func (f *fakeSTTExt) Initialize(_ *extension.Emitter, _ map[string]any, _ string) (*protocol.Registrations, error) {
+	return &protocol.Registrations{STTProviders: f.sttProviders}, nil
+}
+
+func (f *fakeSTTExt) HandleTranscribe(_ context.Context, _ protocol.STTTranscribeParams) (*protocol.STTTranscribeResult, error) {
+	if f.transcribeErr != nil {
+		return nil, f.transcribeErr
+	}
+	if f.transcribeResult != nil {
+		return f.transcribeResult, nil
+	}
+	return &protocol.STTTranscribeResult{
+		Text:       "hello world",
+		Language:   "en",
+		Confidence: 0.95,
+	}, nil
+}
+
+func (f *fakeSTTExt) HandleModels(_ context.Context) (*protocol.STTModelsResult, error) {
+	if f.modelsErr != nil {
+		return nil, f.modelsErr
+	}
+	if f.modelsResult != nil {
+		return f.modelsResult, nil
+	}
+	return &protocol.STTModelsResult{
+		Models: []protocol.STTModel{{ID: "whisper-1", Name: "Whisper"}},
+	}, nil
+}
+
+func (f *fakeSTTExt) Shutdown() error {
+	f.shutdownCalled = true
+	return nil
+}
+
+// runSTTExt starts RunSTT in the background and returns a FakeKova wired to it.
+func runSTTExt(t *testing.T, ext extension.STTExtension) *harness.FakeKova {
+	t.Helper()
+	fk := harness.NewFakeKova(t)
+	go func() {
+		_ = extension.RunSTT(ext,
+			extension.WithStdin(fk.ExtStdin),
+			extension.WithStdout(fk.ExtStdout),
+		)
+	}()
+	return fk
+}
+
+func TestRunSTT_FullLifecycle(t *testing.T) {
+	ext := &fakeSTTExt{
+		sttProviders: []protocol.STTProviderDef{{Name: "test-stt", Description: "test STT"}},
+		transcribeResult: &protocol.STTTranscribeResult{
+			Text:       "hello world",
+			Language:   "en",
+			Confidence: 0.98,
+			Segments: []protocol.STTSegment{
+				{Start: 0.0, End: 0.5, Text: "hello"},
+				{Start: 0.5, End: 1.0, Text: "world"},
+			},
+		},
+		modelsResult: &protocol.STTModelsResult{
+			Models: []protocol.STTModel{
+				{ID: "whisper-1", Name: "Whisper", Language: "en"},
+				{ID: "large-v3", Name: "Large V3", Language: "multilingual"},
+			},
+		},
+	}
+	fk := runSTTExt(t, ext)
+
+	regs := fk.Initialize(nil)
+	if len(regs.STTProviders) != 1 {
+		t.Fatalf("got %d STT providers, want 1", len(regs.STTProviders))
+	}
+	if regs.STTProviders[0].Name != "test-stt" {
+		t.Errorf("STT provider name = %q, want test-stt", regs.STTProviders[0].Name)
+	}
+
+	// Test transcribe.
+	result := fk.Call(protocol.MethodSTTTranscribe, protocol.STTTranscribeParams{
+		AudioBase64: "dGVzdA==",
+		Format:      "opus",
+		Language:    "en",
+	})
+	transcribeResult := harness.MustUnmarshal[protocol.STTTranscribeResult](t, result)
+	if transcribeResult.Text != "hello world" {
+		t.Errorf("text = %q, want hello world", transcribeResult.Text)
+	}
+	if transcribeResult.Language != "en" {
+		t.Errorf("language = %q, want en", transcribeResult.Language)
+	}
+	if transcribeResult.Confidence != 0.98 {
+		t.Errorf("confidence = %f, want 0.98", transcribeResult.Confidence)
+	}
+	if len(transcribeResult.Segments) != 2 {
+		t.Fatalf("got %d segments, want 2", len(transcribeResult.Segments))
+	}
+	if transcribeResult.Segments[0].Text != "hello" {
+		t.Errorf("segment[0].text = %q, want hello", transcribeResult.Segments[0].Text)
+	}
+
+	// Test models.
+	modelsRaw := fk.Call(protocol.MethodSTTModels, nil)
+	modelsResult := harness.MustUnmarshal[protocol.STTModelsResult](t, modelsRaw)
+	if len(modelsResult.Models) != 2 {
+		t.Fatalf("got %d models, want 2", len(modelsResult.Models))
+	}
+	if modelsResult.Models[0].ID != "whisper-1" {
+		t.Errorf("model[0].id = %q, want whisper-1", modelsResult.Models[0].ID)
+	}
+
+	fk.Shutdown()
+}
+
+func TestRunSTT_TranscribeError(t *testing.T) {
+	ext := &fakeSTTExt{
+		transcribeErr: errors.New("transcription failed"),
+	}
+	fk := runSTTExt(t, ext)
+	fk.Initialize(nil)
+
+	rpcErr := fk.CallExpectError(protocol.MethodSTTTranscribe, protocol.STTTranscribeParams{
+		AudioBase64: "dGVzdA==",
+		Format:      "wav",
+	})
+	if rpcErr.Code != protocol.ErrCodeSTTFailed {
+		t.Errorf("code = %d, want %d (ErrCodeSTTFailed)", rpcErr.Code, protocol.ErrCodeSTTFailed)
+	}
+	if rpcErr.Message != "transcription failed" {
+		t.Errorf("message = %q, want %q", rpcErr.Message, "transcription failed")
+	}
+
+	fk.Shutdown()
+}
+
+func TestRunSTT_ModelsError(t *testing.T) {
+	ext := &fakeSTTExt{
+		modelsErr: errors.New("models unavailable"),
+	}
+	fk := runSTTExt(t, ext)
+	fk.Initialize(nil)
+
+	rpcErr := fk.CallExpectError(protocol.MethodSTTModels, nil)
+	if rpcErr.Code != protocol.ErrCodeSTTFailed {
+		t.Errorf("code = %d, want %d (ErrCodeSTTFailed)", rpcErr.Code, protocol.ErrCodeSTTFailed)
+	}
+
+	fk.Shutdown()
+}
+
+func TestRunSTT_UnknownMethod(t *testing.T) {
+	ext := &fakeSTTExt{}
+	fk := runSTTExt(t, ext)
+	fk.Initialize(nil)
+
+	rpcErr := fk.CallExpectError("stt_unknown", nil)
+	if rpcErr.Code != protocol.ErrCodeMethodNotFound {
+		t.Errorf("code = %d, want %d (ErrCodeMethodNotFound)", rpcErr.Code, protocol.ErrCodeMethodNotFound)
+	}
+
+	fk.Shutdown()
+}

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -56,6 +56,12 @@ const (
 	MethodTTSVoices     = "tts_voices"
 )
 
+// Method names for kova -> extension requests (STT).
+const (
+	MethodSTTTranscribe = "stt_transcribe"
+	MethodSTTModels     = "stt_models"
+)
+
 // Method names for kova -> extension requests (voice).
 const (
 	MethodVoiceJoin   = "voice_join"
@@ -97,6 +103,7 @@ const (
 	ErrCodeModelNotFound  = -32012
 	ErrCodeTTSFailed      = -32013
 	ErrCodeVoiceNotFound  = -32014
+	ErrCodeSTTFailed      = -32015
 	ErrCodeHookFailed     = -32020
 	ErrCodeHTTPFailed     = -32021
 	ErrCodeServiceFailed  = -32022

--- a/protocol/initialize.go
+++ b/protocol/initialize.go
@@ -27,6 +27,7 @@ type Registrations struct {
 	Services     []ServiceDef     `json:"services,omitempty"`
 	Providers    []ProviderDef    `json:"providers,omitempty"`
 	TTSProviders []TTSProviderDef `json:"tts_providers,omitempty"`
+	STTProviders []STTProviderDef `json:"stt_providers,omitempty"`
 	CLICommands  []CLIDef         `json:"cli_commands,omitempty"`
 }
 

--- a/protocol/stt.go
+++ b/protocol/stt.go
@@ -1,0 +1,64 @@
+package protocol
+
+// STTTranscribeParams holds the payload for a "stt_transcribe" request.
+type STTTranscribeParams struct {
+	// AudioBase64 is the input audio encoded as base64. Required.
+	AudioBase64 string `json:"audio_base64"`
+	// Format is the audio format of the input data: "opus", "mp3", "flac", "wav", "pcm".
+	// Required so the STT provider knows how to decode.
+	Format string `json:"format"`
+	// SampleRate is the audio sample rate in Hz (e.g., 16000, 48000). Optional.
+	SampleRate int `json:"sample_rate,omitempty"`
+	// Channels is the number of audio channels: 1 for mono, 2 for stereo. Optional.
+	Channels int `json:"channels,omitempty"`
+	// Language is the BCP-47 language code hint (e.g., "en", "fr"). Optional.
+	Language string `json:"language,omitempty"`
+	// Model selects the STT model (e.g., "whisper-1", "large-v3"). Optional.
+	Model string `json:"model,omitempty"`
+	// UserID identifies the user who produced the audio. Optional.
+	UserID string `json:"user_id,omitempty"`
+	// ChannelID identifies the channel the audio came from. Optional.
+	ChannelID string `json:"channel_id,omitempty"`
+}
+
+// STTTranscribeResult is the response for a "stt_transcribe" request.
+type STTTranscribeResult struct {
+	// Text is the full transcription of the audio.
+	Text string `json:"text"`
+	// Language is the detected or confirmed BCP-47 language code.
+	Language string `json:"language,omitempty"`
+	// Confidence is the overall transcription confidence (0.0 to 1.0). Optional.
+	Confidence float64 `json:"confidence,omitempty"`
+	// Segments are word- or phrase-level timing segments. Optional.
+	Segments []STTSegment `json:"segments,omitempty"`
+}
+
+// STTSegment represents a timed segment within a transcription.
+type STTSegment struct {
+	// Start is the segment start time in seconds.
+	Start float64 `json:"start"`
+	// End is the segment end time in seconds.
+	End float64 `json:"end"`
+	// Text is the transcribed text for this segment.
+	Text string `json:"text"`
+}
+
+// STTModelsResult is the response for a "stt_models" request.
+type STTModelsResult struct {
+	Models []STTModel `json:"models"`
+}
+
+// STTModel describes an available model from an STT provider extension.
+type STTModel struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Language    string `json:"language,omitempty"`
+}
+
+// STTProviderDef describes an STT provider an extension registers during
+// initialization. This is included in the Registrations response.
+type STTProviderDef struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}

--- a/schemas/InitializeResult.json
+++ b/schemas/InitializeResult.json
@@ -149,6 +149,27 @@
             "additionalProperties": false
           }
         },
+        "stt_providers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
         "cli_commands": {
           "type": [
             "null",

--- a/schemas/Registrations.json
+++ b/schemas/Registrations.json
@@ -146,6 +146,27 @@
         "additionalProperties": false
       }
     },
+    "stt_providers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
     "cli_commands": {
       "type": [
         "null",

--- a/schemas/STTModel.json
+++ b/schemas/STTModel.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    }
+  },
+  "title": "STTModel",
+  "required": [
+    "id",
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/STTModelsResult.json
+++ b/schemas/STTModelsResult.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "models": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "STTModelsResult",
+  "required": [
+    "models"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/STTProviderDef.json
+++ b/schemas/STTProviderDef.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "title": "STTProviderDef",
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/STTSegment.json
+++ b/schemas/STTSegment.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "start": {
+      "type": "number"
+    },
+    "end": {
+      "type": "number"
+    },
+    "text": {
+      "type": "string"
+    }
+  },
+  "title": "STTSegment",
+  "required": [
+    "start",
+    "end",
+    "text"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/STTTranscribeParams.json
+++ b/schemas/STTTranscribeParams.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "audio_base64": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string"
+    },
+    "sample_rate": {
+      "type": "integer"
+    },
+    "channels": {
+      "type": "integer"
+    },
+    "language": {
+      "type": "string"
+    },
+    "model": {
+      "type": "string"
+    },
+    "user_id": {
+      "type": "string"
+    },
+    "channel_id": {
+      "type": "string"
+    }
+  },
+  "title": "STTTranscribeParams",
+  "required": [
+    "audio_base64",
+    "format"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/STTTranscribeResult.json
+++ b/schemas/STTTranscribeResult.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "confidence": {
+      "type": "number"
+    },
+    "segments": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "number"
+          },
+          "end": {
+            "type": "number"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "text"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "title": "STTTranscribeResult",
+  "required": [
+    "text"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -70,6 +70,12 @@ func allProtocolTypes() map[string]reflect.Type {
 		"TTSSynthesizeResult":         reflect.TypeOf(protocol.TTSSynthesizeResult{}),
 		"TTSVoicesResult":             reflect.TypeOf(protocol.TTSVoicesResult{}),
 		"TTSVoice":                    reflect.TypeOf(protocol.TTSVoice{}),
+		"STTProviderDef":              reflect.TypeOf(protocol.STTProviderDef{}),
+		"STTTranscribeParams":         reflect.TypeOf(protocol.STTTranscribeParams{}),
+		"STTTranscribeResult":         reflect.TypeOf(protocol.STTTranscribeResult{}),
+		"STTSegment":                  reflect.TypeOf(protocol.STTSegment{}),
+		"STTModelsResult":             reflect.TypeOf(protocol.STTModelsResult{}),
+		"STTModel":                    reflect.TypeOf(protocol.STTModel{}),
 		"LogParams":                   reflect.TypeOf(protocol.LogParams{}),
 	}
 }


### PR DESCRIPTION
## Summary

- Add `stt_providers` capability to `Registrations` and `STTProviderDef` type
- Add `STTTranscribeParams`/`STTTranscribeResult` with segments support, and `STTModelsResult`/`STTModel` types
- Add `stt_transcribe` and `stt_models` JSON-RPC method constants and `ErrCodeSTTFailed` error code
- Add `STTExtension` interface, `RunSTT` convenience wrapper, `WithSTT` composite option, and full dispatch/lifecycle wiring
- Add comprehensive tests mirroring the TTS test suite
- Regenerate all JSON schemas

Mirrors the existing TTS provider pattern.

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `go fmt ./...` and `go vet ./...` clean
- [x] Schema generation produces valid schemas matching new types
- [x] Full lifecycle test: initialize with STT provider, transcribe, list models, shutdown
- [x] Error path tests: transcribe failure, models failure, unknown method